### PR TITLE
Add Lint check configs

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,4 @@
+[flake8]
+ignore = E501 # line too long
+         W503 # line break before binary operator
+         E203 # whitespace before ':'

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,0 +1,5 @@
+[settings]
+multi_line_output=3
+include_trailing_comma=True
+line_length=88
+default_section=THIRDPARTY


### PR DESCRIPTION
Add config for isort and flake8. The flake8 config setup so that some
parts (such as line length) is handled by black formatter.

The isort config overrides the default section, otherwise isort might
give different results in different environmentes due to isort might
have different opinions about FIRSTPARTY and THIRDPARTY sw if installed
in system or by for example virtualenv's.